### PR TITLE
Add Symfony 8 support

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,13 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name:
-          - 'PHP 7.4 tests (Symfony 4.4)'
-          - 'PHP 7.4 tests (Symfony 5.1)'
-          - 'PHP 8.0 tests (Symfony 5.2)'
-          - 'PHP 8.0 tests (Symfony 5.3)'
-          - 'PHP 8.0 tests (Symfony 5.4)'
-          - 'PHP 8.0 tests (Symfony 6.0)'
         include:
           - php: '7.4'
             symfony: 4.4.*
@@ -51,7 +44,17 @@ jobs:
             symfony: 6.0.*
           - php: '8.1'
             symfony: 6.0.*
-    name: ${{ matrix.name }}
+          - php: '8.2'
+            symfony: 7.0.*
+          - php: '8.2'
+            symfony: 8.0.*
+          - php: '8.3'
+            symfony: 8.0.*
+          - php: '8.4'
+            symfony: 8.0.*
+          - php: '8.5'
+            symfony: 8.0.*
+    name: PHP ${{ matrix.php }} (Symfony ${{ matrix.symfony }})
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "symfony/form": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+        "symfony/form": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "symfony/framework-bundle": "^4.0 | ^5.0 | ^6.0 | ^7.0",
+        "symfony/framework-bundle": "^4.0 | ^5.0 | ^6.0 | ^7.0 | ^8.0",
         "roave/security-advisories": "dev-master",
         "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^1.11",

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -103,7 +103,7 @@ class Assert
 
             if (\version_compare(PHP_VERSION, '8.0.0') >= 0 && $type instanceof \ReflectionUnionType) {
                 foreach ($type->getTypes() as $t) {
-                    if($t instanceof \ReflectionNamedType) {
+                    if ($t instanceof \ReflectionNamedType) {
                         if (self::isCompatibleWithType($t->getName(), $paramValue) || ($t->allowsNull() && \is_null($paramValue))) {
                             return true;
                         }
@@ -115,7 +115,7 @@ class Assert
 
             if (\version_compare(PHP_VERSION, '8.1.0') >= 0 && $type instanceof \ReflectionIntersectionType) {
                 foreach ($type->getTypes() as $t) {
-                    if($t instanceof \ReflectionNamedType) {
+                    if ($t instanceof \ReflectionNamedType) {
                         if (!self::isCompatibleWithType($t->getName(), $paramValue)) { /* intersection types do not support nullables for now */
                             return false;
                         }
@@ -137,7 +137,6 @@ class Assert
     protected static function isCompatibleWithType(string $type, $value): bool
     {
         if (\is_object($value)) {
-            // @phpstan-ignore-next-line
             return \get_class($value) === $type || \is_subclass_of($value, $type);
         }
 

--- a/src/PageFilterFormTrait.php
+++ b/src/PageFilterFormTrait.php
@@ -6,6 +6,7 @@ namespace Andante\PageFilterFormBundle;
 
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Service\Attribute\Required;
 
 trait PageFilterFormTrait
 {
@@ -34,9 +35,7 @@ trait PageFilterFormTrait
         );
     }
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setPageFilterManager(PageFilterManagerInterface $pageFilterManager): void
     {
         $this->pageFilterManager = $pageFilterManager;

--- a/tests/Form/DumbArrayByValuePageFilterType.php
+++ b/tests/Form/DumbArrayByValuePageFilterType.php
@@ -20,7 +20,7 @@ class DumbArrayByValuePageFilterType extends AbstractType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return PageFilterType::class;
     }

--- a/tests/Form/DumbArrayPageFilterType.php
+++ b/tests/Form/DumbArrayPageFilterType.php
@@ -26,7 +26,7 @@ class DumbArrayPageFilterType extends AbstractType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return PageFilterType::class;
     }

--- a/tests/Form/DumbObjectIntersectionTypeHint1PageFilterType.php
+++ b/tests/Form/DumbObjectIntersectionTypeHint1PageFilterType.php
@@ -23,7 +23,7 @@ class DumbObjectIntersectionTypeHint1PageFilterType extends AbstractType
         }
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return PageFilterType::class;
     }

--- a/tests/Form/DumbObjectNotEnoughParametersPageFilterType.php
+++ b/tests/Form/DumbObjectNotEnoughParametersPageFilterType.php
@@ -19,7 +19,7 @@ class DumbObjectNotEnoughParametersPageFilterType extends AbstractType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return PageFilterType::class;
     }

--- a/tests/Form/DumbObjectPageFilterType.php
+++ b/tests/Form/DumbObjectPageFilterType.php
@@ -26,7 +26,7 @@ class DumbObjectPageFilterType extends AbstractType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return PageFilterType::class;
     }

--- a/tests/Form/DumbObjectUnionTypeHint1PageFilterType.php
+++ b/tests/Form/DumbObjectUnionTypeHint1PageFilterType.php
@@ -23,7 +23,7 @@ class DumbObjectUnionTypeHint1PageFilterType extends AbstractType
         }
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return PageFilterType::class;
     }

--- a/tests/Form/DumbObjectWrongTypeHint1PageFilterType.php
+++ b/tests/Form/DumbObjectWrongTypeHint1PageFilterType.php
@@ -19,7 +19,7 @@ class DumbObjectWrongTypeHint1PageFilterType extends AbstractType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return PageFilterType::class;
     }

--- a/tests/Form/DumbObjectWrongTypeHint2PageFilterType.php
+++ b/tests/Form/DumbObjectWrongTypeHint2PageFilterType.php
@@ -20,7 +20,7 @@ class DumbObjectWrongTypeHint2PageFilterType extends AbstractType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return PageFilterType::class;
     }

--- a/tests/Form/DumbObjectWrongTypeHint3PageFilterType.php
+++ b/tests/Form/DumbObjectWrongTypeHint3PageFilterType.php
@@ -19,7 +19,7 @@ class DumbObjectWrongTypeHint3PageFilterType extends AbstractType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return PageFilterType::class;
     }

--- a/tests/Form/DumbObjectWrongTypeHintNoNullableArgs2PageFilterType.php
+++ b/tests/Form/DumbObjectWrongTypeHintNoNullableArgs2PageFilterType.php
@@ -19,7 +19,7 @@ class DumbObjectWrongTypeHintNoNullableArgs2PageFilterType extends AbstractType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return PageFilterType::class;
     }

--- a/tests/Functional/SetUpTest.php
+++ b/tests/Functional/SetUpTest.php
@@ -22,11 +22,9 @@ class SetUpTest extends KernelTestCase
         /** @var DumbService $dumbService */
         $dumbService = self::getContainer()->get(DumbService::class);
         $rProperty = new \ReflectionProperty($dumbService, 'pageFilterManager');
-        $rProperty->setAccessible(true);
         $filterManager = $rProperty->getValue($dumbService);
         self::assertInstanceOf(PageFilterManagerInterface::class, $filterManager);
         $rProperty = new \ReflectionProperty($filterManager, 'formFactory');
-        $rProperty->setAccessible(true);
         self::assertInstanceOf(FormFactoryInterface::class, $rProperty->getValue($filterManager));
     }
 }


### PR DESCRIPTION
- Add `^8.0` to `symfony/form` and `symfony/framework-bundle` version constraints
- Add test matrix for PHP 8.2-8.5 with Symfony 8
- Use `#[Required]` attribute instead of `@required` annotation (Symfony 8 compat)
- Add return types to test classes for PHP 8.5 compat