### PR TITLE
Use non-deprecated Extension base class

### DIFF
--- a/src/DependencyInjection/AndantePageFilterFormExtension.php
+++ b/src/DependencyInjection/AndantePageFilterFormExtension.php
@@ -10,8 +10,8 @@ use Andante\PageFilterFormBundle\PageFilterManager;
 use Andante\PageFilterFormBundle\PageFilterManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class AndantePageFilterFormExtension extends Extension
 {


### PR DESCRIPTION
Fixes #3

Use `Symfony\Component\DependencyInjection\Extension\Extension` instead of the internal `Symfony\Component\HttpKernel\DependencyInjection\Extension`.